### PR TITLE
chore: conform README and pipeline to canonical standards

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -30,8 +30,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  pre-commit:
-    name: Pre-commit checks
+  code-quality:
+    name: Code quality
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -57,10 +57,10 @@ jobs:
       - name: Run pre-commit hooks
         run: uv run pre-commit run --all-files
 
-  security-scan:
-    name: Security scanning
+  security:
+    name: Security
     runs-on: ubuntu-latest
-    needs: [pre-commit]
+    needs: [code-quality]
     permissions:
       contents: read
       security-events: write
@@ -160,10 +160,10 @@ jobs:
             pip-audit-report.json
             security-reports.html
 
-  compliance-reports:
-    name: License compliance
+  compliance:
+    name: Compliance
     runs-on: ubuntu-latest
-    needs: [pre-commit]
+    needs: [code-quality]
     permissions:
       contents: read
 
@@ -221,10 +221,40 @@ jobs:
             license-report.json
             license-report.html
 
+  build-validation:
+    name: Build validation
+    runs-on: ubuntu-latest
+    needs: [code-quality]
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install UV
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Build distribution
+        run: uv build
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: dist
+          path: dist/
 
   unit-tests:
     name: Unit tests
-    needs: [pre-commit]
+    needs: [code-quality]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -276,7 +306,7 @@ jobs:
   deploy-test-infrastructure:
     name: Deploy test infrastructure
     runs-on: ubuntu-latest
-    needs: [security-scan]
+    needs: [security]
     if: |
       github.event_name == 'push' &&
       (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') &&
@@ -410,7 +440,7 @@ jobs:
 
   release:
     name: Semantic release
-    needs: [unit-tests, integration-tests, security-scan, compliance-reports]
+    needs: [unit-tests, integration-tests, security, compliance, build-validation]
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
     runs-on: ubuntu-latest
     concurrency:

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1,0 +1,113 @@
+# Tagmania Examples
+
+Real-world usage patterns. Each example assumes:
+
+- You have the [Minimum IAM Policy](README.md#minimum-iam-policy) attached to whatever AWS identity you're using.
+- Your EC2 instances carry a `Cluster` tag that matches the name you pass.
+- Your instance `Name` tags are set -- targeted restores and log output both depend on them.
+
+---
+
+## 1. Back up and restore a whole cluster
+
+Back up every attached EBS volume on every instance in a cluster, then restore from the same snapshot set later.
+
+```bash
+# Take a named snapshot of the whole cluster.
+# This stops instances first, snapshots all attached volumes, then leaves
+# instances stopped. Start them again with cluster-start.
+cluster-snap --backup --name pre-upgrade my-cluster
+
+# ... do risky work ...
+
+# Roll every volume back to the snapshot set. Again, leaves instances stopped.
+cluster-snap --restore --name pre-upgrade my-cluster
+cluster-start my-cluster
+```
+
+What happens during restore:
+
+1. Stop every instance in `my-cluster`.
+2. Detach every managed volume.
+3. Delete the detached volumes.
+4. Create fresh volumes from the snapshots tagged `Label=pre-upgrade`.
+5. Attach the new volumes back to their original instance + device.
+
+Instances stay stopped at the end -- you run `cluster-start` when you're ready to bring the cluster back up. This gives you a chance to verify volumes are attached correctly before boot.
+
+---
+
+## 2. Targeted restore with a regex
+
+Restore only a subset of the cluster -- handy when one service is misbehaving but you don't want to roll everything back.
+
+```bash
+# Roll back only the web tier. The regex matches against the Name tag.
+cluster-snap --restore --target ".*-web-.*" --name pre-upgrade my-cluster
+
+# Roll back a specific instance by exact name.
+cluster-snap --restore --target "my-cluster-db-01" --name pre-upgrade my-cluster
+```
+
+Common patterns:
+
+| Pattern | Matches |
+|---------|---------|
+| `".*-web-.*"` | any instance whose Name contains `-web-` |
+| `"worker-[0-9]+"` | `worker-1`, `worker-2`, ... |
+| `"prod-api-.*"` | every prod API box |
+| `"db-01"` | exactly the one DB box named `db-01` |
+
+The CLI prints the list of matched instances and asks for `yes` before touching anything.
+
+---
+
+## 3. Scheduled overnight snapshots via cron
+
+Back up a dev cluster every night, keeping only the last snapshot per label. Tagmania's `--backup --name X` overwrites any prior snapshot set that shares the same label, so you get one rolling snapshot per label without any extra bookkeeping.
+
+```bash
+# ~/.aws/credentials or an instance role must provide the AWS identity.
+# Example crontab entry -- nightly at 2am UTC:
+0 2 * * * /usr/local/bin/cluster-snap --backup --name nightly dev-cluster
+```
+
+Notes:
+
+- This replaces the `nightly` snapshot set every night -- you keep one-deep history.
+- To keep a week of rolling history, schedule seven jobs with day-of-week labels:
+
+  ```cron
+  0 2 * * 0 /usr/local/bin/cluster-snap --backup --name sun dev-cluster
+  0 2 * * 1 /usr/local/bin/cluster-snap --backup --name mon dev-cluster
+  # ... through Saturday
+  ```
+
+- `cluster-snap --backup` stops instances before snapshotting. For a dev cluster that's usually fine. For a production cluster, plan maintenance windows around this.
+
+---
+
+## 4. Cross-region snapshots -- what doesn't work
+
+Tagmania operates within whatever region the AWS CLI profile points to. **EBS snapshots are region-scoped**, and Tagmania does not copy snapshots across regions.
+
+If you need cross-region disaster-recovery copies, do the copy yourself with the AWS CLI after Tagmania runs:
+
+```bash
+# Take snapshots in the primary region.
+cluster-snap --backup --name dr-primary my-cluster --profile us-east-1
+
+# Use aws ec2 copy-snapshot to replicate each snapshot to the DR region.
+# Tagmania's snapshots carry automation_key=SNAPSHOT_MANAGER and
+# Label=dr-primary, so you can filter to just the ones you care about:
+aws --profile us-east-1 ec2 describe-snapshots \
+  --filters "Name=tag:automation_key,Values=SNAPSHOT_MANAGER" \
+            "Name=tag:Label,Values=dr-primary" \
+  --query 'Snapshots[].SnapshotId' --output text \
+  | xargs -n1 -I{} aws --profile us-east-1 ec2 copy-snapshot \
+      --source-region us-east-1 \
+      --destination-region us-west-2 \
+      --source-snapshot-id {}
+```
+
+Restoring in the DR region would require creating a matching cluster there (same `Cluster` tag), then manually attaching volumes created from the copied snapshots -- Tagmania's restore assumes the source snapshots live in the same region as the target cluster.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,20 @@
 # Tagmania
 
-
 [![CI Status](https://github.com/svange/tagmania/actions/workflows/pipeline.yaml/badge.svg?branch=main)](https://github.com/svange/tagmania/actions/workflows/pipeline.yaml)
-
 [![PyPI](https://img.shields.io/pypi/v/tagmania?style=flat-square)](https://pypi.org/project/tagmania/)
-[![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg?style=flat-square)](https://github.com/astral-sh/ruff)
-[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?style=flat-square&logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
-[![GitHub Actions](https://img.shields.io/badge/GitHub_Actions-automated-blue?style=flat-square&logo=github-actions&logoColor=white)](https://github.com/features/actions)
-[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg?style=flat-square)](https://conventionalcommits.org)
 [![semantic-release](https://img.shields.io/badge/%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg?style=flat-square)](https://github.com/semantic-release/semantic-release)
 [![License](https://img.shields.io/github/license/svange/tagmania?style=flat-square)](https://github.com/svange/tagmania/blob/main/LICENSE)
 
+Manic tools for manipulating sets of tagged resources in AWS.
 
 ---
 
-## Project Resources
+## Pipeline Artifacts
 
-| Resource | Link |
-|----------|------|
+> Reports are published to GitHub Pages on every release to `main`.
+
+| Report | Link |
+|--------|------|
 | API Documentation | [svange.github.io/tagmania](https://svange.github.io/tagmania/) |
 | Test Report | [tests/test-report.html](https://svange.github.io/tagmania/tests/test-report.html) |
 | Coverage Report | [coverage/](https://svange.github.io/tagmania/coverage/) |
@@ -25,50 +22,82 @@
 | License Compliance | [compliance/license-report.html](https://svange.github.io/tagmania/compliance/license-report.html) |
 | PyPI | [pypi.org/project/tagmania](https://pypi.org/project/tagmania/) |
 
-### Pipeline Artifacts
-
-The CI/CD pipeline generates downloadable artifacts for each run:
-
-| Artifact | Contents |
-|----------|----------|
-| **security-scan-results** | `bandit-report.json`, `pip-audit-report.json`, `security-reports.html` |
-| **compliance-reports** | `license-report.json`, `license-report.html` |
-| **coverage-reports** | `htmlcov/`, `coverage.xml`, `coverage.json` |
-| **unit-test-reports** | `test-report.html` |
-| **distribution-artifacts** | Built wheel and sdist in `dist/` (on release) |
-
-Download from the [Actions tab](https://github.com/svange/tagmania/actions) > select a run > scroll to "Artifacts".
+Per-run downloadable artifacts (`bandit-report.json`, `pip-audit-report.json`, `coverage.xml`, `test-report.html`, `license-report.json`, built `dist/` on release) are available under the [Actions tab](https://github.com/svange/tagmania/actions) > select a run > scroll to "Artifacts".
 
 ---
 
-## Overview
+## What This Does
 
-Tagmania provides command-line tools for managing AWS EC2 clusters through tag-based operations. It offers utilities for starting, stopping, and creating snapshots of clusters identified by their "Cluster" tag.
+Tagmania is a command-line toolkit for managing groups of AWS EC2 instances that share a `Cluster` tag. You point it at a cluster name and it can start, stop, snapshot, or restore every instance in that cluster as a single unit. It's useful if you run dev/test environments on EC2 and want a simple way to pause them overnight, back them up before risky changes, or roll an entire cluster back to a known-good state.
 
-**Key Requirements:**
-- EC2 instances must have "Cluster" tag to identify cluster membership
-- Instance "Name" tags are used for targeted operations
-- AWS CLI profile configuration required for authentication
+It operates only on resources it's been told to manage (via a `SNAPSHOT_MANAGER` automation tag), so it won't accidentally touch unrelated resources in your account.
 
-## Installation
+---
 
-### Quick Install
+## Getting Started
+
+> This project uses AI-assisted development. You do not need to memorize
+> git commands or CI configuration -- your AI agent handles that.
+
+### Prerequisites
+
+- Python 3.12 or higher
+- An AWS account with EC2 access
+- An AWS CLI profile configured (e.g. via `aws configure`)
+- EC2 instances tagged with a `Cluster` tag identifying their membership
+- IAM permissions for the `ec2:*` actions listed in the [template IAM policy](template.yaml) (read + start/stop + snapshot/volume lifecycle)
+
+### First-time setup
 
 ```bash
 pip install tagmania
+# or, with uv
+uv tool install tagmania
 ```
 
-### Version Management
-
-For production environments, always pin to a specific version:
+For production, pin to an exact version:
 
 ```bash
-pip install tagmania==2.4.0
+pip install tagmania==2.6.1
 ```
 
-See [Version Management](#version-management-and-stability) for detailed guidance on version pinning and stability.
+### Running locally
 
-### AWS Cost Warning
+```bash
+cluster-start  my-cluster                 # boot all instances in my-cluster
+cluster-stop   my-cluster                 # stop all instances in my-cluster
+cluster-snap --backup  my-cluster         # snapshot every attached EBS volume
+cluster-snap --restore my-cluster         # restore volumes from most recent snapshot
+cluster-snap --list    my-cluster         # list snapshots for the cluster
+```
+
+All commands accept `--profile <aws-profile>` for credential selection. See [Available Commands](#available-commands) and [Advanced Features](#advanced-features) below for more.
+
+---
+
+## How to Contribute
+
+> Contributions are made through AI agents (Claude Code, Copilot, etc.).
+> You describe what you want changed in plain language; the agent handles
+> branching, coding, testing, and submitting a pull request.
+
+1. **Open Claude Code** (or your AI agent) in this repo.
+2. **Describe the change** you want -- a bug fix, a new feature, a doc update.
+3. The agent will:
+   - Create a feature branch
+   - Make the changes
+   - Run pre-commit checks and tests
+   - Open a pull request
+4. **Review the PR** when the agent is done. CI runs automatically.
+5. **Merge** once CI is green.
+
+If you need to work manually, see the full [contributor guide](CONTRIBUTING.md).
+
+---
+
+<!-- Custom sections preserved from previous README -->
+
+## AWS Cost Warning
 
 **⚠️ Important**: This tool operates on AWS infrastructure and can incur costs:
 - EBS snapshot storage charges apply for all created snapshots
@@ -193,30 +222,30 @@ To ensure consistent and stable deployments, it is critical to pin Tagmania to s
 
 **pip with version pinning:**
 ```bash
-pip install tagmania==2.4.0
+pip install tagmania==2.6.1
 ```
 
 **Poetry (recommended for projects):**
 ```toml
 [tool.poetry.dependencies]
-tagmania = "2.4.0"
+tagmania = "2.6.1"
 ```
 
 **Requirements.txt:**
 ```
-tagmania==2.4.0
+tagmania==2.6.1
 ```
 
 ### Version Selection Strategy
 
 **Production Environments:**
-- Always use exact version pinning (e.g., `==2.4.0`)
+- Always use exact version pinning (e.g., `==2.6.1`)
 - Test new versions in development/staging before production deployment
 - Document version upgrade procedures and rollback plans
 - Monitor release notes for breaking changes
 
 **Development Environments:**
-- Use compatible version ranges for feature development (e.g., `~=2.4.0`)
+- Use compatible version ranges for feature development (e.g., `~=2.6.1`)
 - Pin to exact versions when reproducing production issues
 - Update regularly to stay current with security patches
 
@@ -239,24 +268,14 @@ print(tagmania.__version__)
 pip freeze > requirements-backup.txt
 
 # Upgrade to specific version
-pip install tagmania==2.5.0
+pip install tagmania==2.6.1
 
 # Test functionality
 cluster-snap --list test-cluster
 
 # If issues occur, rollback
-pip install tagmania==2.4.0
+pip install tagmania==2.5.0
 ```
-
-## Contributing
-
-We welcome contributions! Tagmania uses a fork-based development model to ensure code quality and maintain project integrity.
-
-Please see our [Contributing Guide](CONTRIBUTING.md) for detailed instructions on:
-- Setting up your development environment
-- Creating and maintaining your fork
-- Submitting pull requests
-- Following our coding standards and commit conventions
 
 ## Troubleshooting
 
@@ -264,13 +283,13 @@ Please see our [Contributing Guide](CONTRIBUTING.md) for detailed instructions o
 - **Invalid regex**: Test regex patterns before using with targeted operations
 - **Permission errors**: Ensure AWS profile has EC2 and EBS permissions
 - **Timeout issues**: Large volumes may take time to snapshot/restore
-- **Python compatibility**: Requires Python 3.9 or higher
+- **Python compatibility**: Requires Python 3.12 or higher
 
 ## Support
 
-- 📖 [Documentation](https://svange.github.io/tagmania)
-- 🐛 [Issue Tracker](https://github.com/svange/tagmania/issues)
-- 💬 [Discussions](https://github.com/svange/tagmania/discussions)
+- [Documentation](https://svange.github.io/tagmania)
+- [Issue Tracker](https://github.com/svange/tagmania/issues)
+- [Discussions](https://github.com/svange/tagmania/discussions)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,10 @@ It operates only on resources it's been told to manage (via a `SNAPSHOT_MANAGER`
 
 ### Prerequisites
 
-- Python 3.12 or higher
-- An AWS account with EC2 access
-- An AWS CLI profile configured (e.g. via `aws configure`)
-- EC2 instances tagged with a `Cluster` tag identifying their membership
-- IAM permissions for the `ec2:*` actions listed in the [template IAM policy](template.yaml) (read + start/stop + snapshot/volume lifecycle)
+- **Python 3.12 or higher** (`python --version`)
+- **AWS CLI profile** configured via `aws configure` or `~/.aws/credentials`
+- **EC2 instances tagged** with a `Cluster` tag identifying their membership
+- **IAM permissions** -- see [Minimum IAM Policy](#minimum-iam-policy) below
 
 ### First-time setup
 
@@ -71,7 +70,78 @@ cluster-snap --restore my-cluster         # restore volumes from most recent sna
 cluster-snap --list    my-cluster         # list snapshots for the cluster
 ```
 
-All commands accept `--profile <aws-profile>` for credential selection. See [Available Commands](#available-commands) and [Advanced Features](#advanced-features) below for more.
+All commands accept `--profile <aws-profile>` for credential selection. See [Available Commands](#available-commands) and [Advanced Features](#advanced-features) below for more. Additional end-to-end walkthroughs live in [EXAMPLES.md](EXAMPLES.md).
+
+### Minimum IAM Policy
+
+The AWS identity running Tagmania needs the following permissions. Replace `my-cluster` with your actual `Cluster` tag value (or use a wildcard list if you manage multiple clusters).
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "EC2Read",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeInstances",
+        "ec2:DescribeSnapshots",
+        "ec2:DescribeVolumes",
+        "ec2:DescribeImages",
+        "ec2:DescribeAvailabilityZones"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "InstanceStartStop",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:StartInstances",
+        "ec2:StopInstances"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": { "ec2:ResourceTag/Cluster": ["my-cluster"] }
+      }
+    },
+    {
+      "Sid": "VolumeLifecycleTagged",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteVolume",
+        "ec2:AttachVolume",
+        "ec2:DetachVolume",
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": { "ec2:ResourceTag/Cluster": ["my-cluster"] }
+      }
+    },
+    {
+      "Sid": "VolumeCreate",
+      "Effect": "Allow",
+      "Action": ["ec2:CreateVolume"],
+      "Resource": "*"
+    },
+    {
+      "Sid": "SnapshotLifecycle",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateSnapshot",
+        "ec2:DeleteSnapshot",
+        "ec2:CreateTags"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+The tagged conditions restrict the blast radius of start/stop and volume-modifying calls to instances that carry the matching `Cluster` tag. `CreateVolume` and snapshot create/delete are not tag-conditioned because AWS doesn't support that tag condition during resource creation.
+
+The `template.yaml` in this repo uses the same policy shape for integration-test infrastructure.
 
 ---
 
@@ -92,6 +162,34 @@ All commands accept `--profile <aws-profile>` for credential selection. See [Ava
 5. **Merge** once CI is green.
 
 If you need to work manually, see the full [contributor guide](CONTRIBUTING.md).
+
+---
+
+## Architecture
+
+Tagmania is a thin layer on top of `boto3`. Every CLI entry point instantiates a `ClusterSet`, which owns an EC2 resource + client and exposes tag-scoped operations on instances, volumes, and snapshots.
+
+```mermaid
+flowchart LR
+    CLI["CLI entry points<br/>cluster-start / cluster-stop / cluster-snap"]
+    CS["ClusterSet<br/>(src/tagmania/iac_tools/clusterset.py)"]
+    subgraph boto3[boto3]
+      EC2R["EC2 resource"]
+      EC2C["EC2 client"]
+    end
+    TS["TagSet<br/>[{Key, Value}, ...]"]
+    FS["FilterSet<br/>[{Name, Values}, ...]"]
+
+    CLI --> CS
+    CS --> EC2R
+    CS --> EC2C
+    CS --> TS
+    CS --> FS
+```
+
+- **ClusterSet** is the only class that issues AWS API calls. It enforces a `_MAX_ITEMS = 150` safety cap and only touches resources tagged with its `AUTOMATION_KEY = "SNAPSHOT_MANAGER"`.
+- **TagSet** and **FilterSet** are tiny wrappers around the two shapes of list-of-dicts that AWS uses (`[{Key, Value}]` for tags, `[{Name, Values}]` for filters).
+- **Snapshot / volume lifecycles** run sequentially inside `ClusterSet.create_snapshots` and `create_volumes`. Targeted variants (`*_targeted`) filter by regex against the instance `Name` tag for partial cluster operations.
 
 ---
 
@@ -279,11 +377,12 @@ pip install tagmania==2.5.0
 
 ## Troubleshooting
 
-- **No instances found**: Verify "Cluster" tag exists and matches exactly
-- **Invalid regex**: Test regex patterns before using with targeted operations
-- **Permission errors**: Ensure AWS profile has EC2 and EBS permissions
-- **Timeout issues**: Large volumes may take time to snapshot/restore
-- **Python compatibility**: Requires Python 3.12 or higher
+- **`No instances found`**: The `Cluster` tag doesn't match any running or stopped instance. Tags are case-sensitive; verify with `aws ec2 describe-instances --filters Name=tag:Cluster,Values=my-cluster`.
+- **`UnauthorizedOperation` / `AccessDenied`**: The AWS identity is missing one of the required permissions. See the [Minimum IAM Policy](#minimum-iam-policy) -- most permission errors come from the conditioned `ec2:StartInstances` / `ec2:StopInstances` / volume actions when the caller's `Cluster` tag restriction doesn't include the cluster you're operating on.
+- **`Invalid regex pattern`**: Targeted restore (`--target`) validates its regex before running. Test patterns with a quick `--list` or `python -c "import re; re.compile('...')"` before passing to `--restore`.
+- **Snapshot completes but restore hangs**: Large EBS volumes (>1TB) can exceed the default 60-minute waiter timeout. The waiter polls every 5s for up to 720 attempts; watch the log for the `create_snapshots took Xs` timing line to gauge duration.
+- **`InvalidSnapshot.NotFound`**: The snapshot label doesn't exist for this cluster. List labels with `cluster-snap --list my-cluster`.
+- **Python compatibility**: Requires Python 3.12 or higher (see `pyproject.toml`).
 
 ## Support
 


### PR DESCRIPTION
## Summary

Brings this repo in line with the canonical ai-standardize contract for README and pipeline job vocabulary, plus fixes a stale Python version mention.

### Pipeline

- **Renamed jobs to canonical gate vocabulary** (both key and display name):
  - `pre-commit` -> `code-quality`
  - `security-scan` -> `security`
  - `compliance-reports` -> `compliance`
- Updated all `needs:` references accordingly.
- **Added `build-validation` job** (\`uv build\`) that runs on every PR so packaging errors surface before release. Added to `release`'s `needs:` list.

Note: if there are branch-protection rulesets listing required checks by the old names, they'll need to be updated to match the new display names.

### README

- Restructured against the canonical template: badges -> Pipeline Artifacts table -> What This Does -> Getting Started -> How to Contribute.
- Trimmed badge row to CI / PyPI / semantic-release / License.
- Preserved existing user-facing content as "Custom sections" below the canonical sections: AWS Cost Warning, Available Commands, Quick Start, Advanced Features, How It Works, Safety Features, Version Management, Troubleshooting, Support, Sponsor.
- Fixed stale "Python 3.9" claim in Troubleshooting (pyproject requires >=3.12).

### Closes

Closes #3 -- per decision, badge/codecov additions were intentionally deferred; this PR covers the "conform to our standards" part of the issue.

## Test plan

- [ ] CI pipeline runs with the renamed jobs
- [ ] Build-validation job produces a `dist/` artifact on PR
- [ ] README renders correctly on GitHub (badges load, tables render, links resolve)
- [ ] Release job still runs on push to main once this merges