### PR TITLE
feat: log duration of snapshot create/restore operations

### DIFF
--- a/src/tagmania/iac_tools/clusterset.py
+++ b/src/tagmania/iac_tools/clusterset.py
@@ -53,6 +53,7 @@ import boto3
 
 from .filterset import FilterSet
 from .tagset import TagSet
+from .timing import log_duration
 
 
 class ClusterSet:
@@ -564,51 +565,52 @@ class ClusterSet:
             none
         """
         self._logger.debug("method_call: create_managed_volumes")
-        snapshots = self.get_snapshots(label)
-        # Check if snapshot list is empty (e.g. due to an invalid label)
-        if len(snapshots) == 0:
-            print(f"Error: No snapshots found with label '{label}'.")
-        # Create volumes
-        volume_ids = []
-        for snapshot in snapshots:
-            # Determine snapshot's associated instance and device. This is
-            # needed later on so that we know where to attach it.
-            ts = TagSet(snapshot.tags)
-            device = ts.get("Device")
-            instance = ts.get("Instance")
-            if not device:
-                raise Exception(
-                    f"Error: create_volume: Can't find device tag for snapshot {snapshot.id}."
+        with log_duration(self._logger, "create_volumes"):
+            snapshots = self.get_snapshots(label)
+            # Check if snapshot list is empty (e.g. due to an invalid label)
+            if len(snapshots) == 0:
+                print(f"Error: No snapshots found with label '{label}'.")
+            # Create volumes
+            volume_ids = []
+            for snapshot in snapshots:
+                # Determine snapshot's associated instance and device. This is
+                # needed later on so that we know where to attach it.
+                ts = TagSet(snapshot.tags)
+                device = ts.get("Device")
+                instance = ts.get("Instance")
+                if not device:
+                    raise Exception(
+                        f"Error: create_volume: Can't find device tag for snapshot {snapshot.id}."
+                    )
+                if not instance:
+                    raise Exception(
+                        f"Error: create_volume: Can't find instance tag for snapshot {snapshot.id}."
+                    )
+                # Determine availability zone from one of the cluster instances
+                avail_zone = self.get_instances()[0].placement["AvailabilityZone"]
+                # Make tags
+                ts = TagSet()
+                ts.add("Cluster", self._cluster_name_str)
+                ts.add("Device", device)
+                ts.add("Instance", instance)
+                ts.add("Label", label)
+                ts.add("Name", f"{instance} - {device}")
+                ts.add("automation_key", self.AUTOMATION_KEY)
+                tags = ts.to_list()
+                # Create volume
+                print(f"Creating volume from snapshot {snapshot.id}")
+                volume = self._ec2.create_volume(
+                    SnapshotId=snapshot.id,
+                    AvailabilityZone=avail_zone,
+                    VolumeInitializationRate=300,
+                    TagSpecifications=[{"ResourceType": "volume", "Tags": tags}],
                 )
-            if not instance:
-                raise Exception(
-                    f"Error: create_volume: Can't find instance tag for snapshot {snapshot.id}."
-                )
-            # Determine availability zone from one of the cluster instances
-            avail_zone = self.get_instances()[0].placement["AvailabilityZone"]
-            # Make tags
-            ts = TagSet()
-            ts.add("Cluster", self._cluster_name_str)
-            ts.add("Device", device)
-            ts.add("Instance", instance)
-            ts.add("Label", label)
-            ts.add("Name", f"{instance} - {device}")
-            ts.add("automation_key", self.AUTOMATION_KEY)
-            tags = ts.to_list()
-            # Create volume
-            print(f"Creating volume from snapshot {snapshot.id}")
-            volume = self._ec2.create_volume(
-                SnapshotId=snapshot.id,
-                AvailabilityZone=avail_zone,
-                VolumeInitializationRate=300,
-                TagSpecifications=[{"ResourceType": "volume", "Tags": tags}],
-            )
-            volume_ids.append(volume.id)
-        # Wait for the volumes to be created
-        if len(volume_ids) > 0:
-            print(f"Waiting for {len(volume_ids)} volumes to be created...")
-            self.wait_for_volumes(volume_ids, "volume_available")
-            self._wait_for_volume_tags(volume_ids)
+                volume_ids.append(volume.id)
+            # Wait for the volumes to be created
+            if len(volume_ids) > 0:
+                print(f"Waiting for {len(volume_ids)} volumes to be created...")
+                self.wait_for_volumes(volume_ids, "volume_available")
+                self._wait_for_volume_tags(volume_ids)
 
     def delete_volumes(self) -> None:
         """
@@ -620,24 +622,25 @@ class ClusterSet:
             none
         """
         self._logger.debug("method_call: delete_volumes")
-        # We really only have to delete the previously detached volumes, but
-        # this will delete all managed volumes in the cluster. Its probably a
-        # good idea to do so as a matter of good housekeeping. Also, if there
-        # are any stale volumes hanging around with the same label that we are
-        # about to restore from that would cause problems because we wouldn't
-        # know which volumes to attach.
-        volumes = self.get_volumes()
-        if len(volumes) == 0:
-            print("No volumes to delete.")
-        else:
-            volume_ids = []
-            for volume in volumes:
-                print(f"Deleting volume {volume.id}")
-                volume.delete()
-                volume_ids.append(volume.id)
-            # Wait for the volumes to be deleted
-            print(f"Waiting for {len(volume_ids)} volumes to be deleted...")
-            self.wait_for_volumes(volume_ids, "volume_deleted")
+        with log_duration(self._logger, "delete_volumes"):
+            # We really only have to delete the previously detached volumes, but
+            # this will delete all managed volumes in the cluster. Its probably a
+            # good idea to do so as a matter of good housekeeping. Also, if there
+            # are any stale volumes hanging around with the same label that we are
+            # about to restore from that would cause problems because we wouldn't
+            # know which volumes to attach.
+            volumes = self.get_volumes()
+            if len(volumes) == 0:
+                print("No volumes to delete.")
+            else:
+                volume_ids = []
+                for volume in volumes:
+                    print(f"Deleting volume {volume.id}")
+                    volume.delete()
+                    volume_ids.append(volume.id)
+                # Wait for the volumes to be deleted
+                print(f"Waiting for {len(volume_ids)} volumes to be deleted...")
+                self.wait_for_volumes(volume_ids, "volume_deleted")
 
     def delete_kubernetes_volumes(self) -> None:
         """
@@ -780,53 +783,54 @@ class ClusterSet:
             none
         """
         self._logger.debug("method_call: create_snapshots")
-        # Check if any snapshots with the same label already exists. If so,
-        # delete them. Only one set of snapshots with a given label may
-        # exist at a time.
-        old_snapshots = self.get_snapshots(label)
-        if len(old_snapshots) > 0:
-            self.delete_snapshots(label)
-        snapshot_ids = []
-        # Get list of instances that need snapshots taken
-        instances = self.get_instances()
-        for i in instances:
-            instance_name = TagSet(i.tags).get("Name") or ""
-            # Get collection of volumes for the current instance
-            volumes = i.volumes.all()
-            for volume in volumes:
-                device = volume.attachments[0]["Device"]
-                # Make description
-                timestamp = datetime.datetime.now(tz=datetime.UTC)
-                date = timestamp.strftime("%Y-%m-%d")
-                time = timestamp.strftime("%H:%M:%S")
-                description = f"Managed snapshot taken on {date} at {time}"
-                # Make tags
-                ts = TagSet()
-                ts.add("Cluster", self._cluster_name_str)
-                ts.add("Device", device)
-                ts.add("Instance", instance_name)
-                ts.add("Label", label)
-                ts.add("Name", f"{instance_name} - {device}")
-                ts.add("automation_key", self.AUTOMATION_KEY)
-                tags = ts.to_list()
-                # Create shapshot
-                shortname = instance_name.split(".")[0]
-                print(f"Creating snapshot of {device} ({volume.id}) on {shortname} ({i.id})")
-                snapshot = volume.create_snapshot(
-                    Description=description,
-                    TagSpecifications=[{"ResourceType": "snapshot", "Tags": tags}],
-                )
-                snapshot_ids.append(snapshot.id)
-        # Wait for snapshots to complete
-        print(f"Waiting for {len(snapshot_ids)} snapshots to complete...")
-        waiter = self._ec2_client.get_waiter("snapshot_completed")
-        waiter.wait(
-            SnapshotIds=snapshot_ids,
-            WaiterConfig={
-                "Delay": 5,
-                "MaxAttempts": 720,
-            },
-        )
+        with log_duration(self._logger, "create_snapshots"):
+            # Check if any snapshots with the same label already exists. If so,
+            # delete them. Only one set of snapshots with a given label may
+            # exist at a time.
+            old_snapshots = self.get_snapshots(label)
+            if len(old_snapshots) > 0:
+                self.delete_snapshots(label)
+            snapshot_ids = []
+            # Get list of instances that need snapshots taken
+            instances = self.get_instances()
+            for i in instances:
+                instance_name = TagSet(i.tags).get("Name") or ""
+                # Get collection of volumes for the current instance
+                volumes = i.volumes.all()
+                for volume in volumes:
+                    device = volume.attachments[0]["Device"]
+                    # Make description
+                    timestamp = datetime.datetime.now(tz=datetime.UTC)
+                    date = timestamp.strftime("%Y-%m-%d")
+                    timestr = timestamp.strftime("%H:%M:%S")
+                    description = f"Managed snapshot taken on {date} at {timestr}"
+                    # Make tags
+                    ts = TagSet()
+                    ts.add("Cluster", self._cluster_name_str)
+                    ts.add("Device", device)
+                    ts.add("Instance", instance_name)
+                    ts.add("Label", label)
+                    ts.add("Name", f"{instance_name} - {device}")
+                    ts.add("automation_key", self.AUTOMATION_KEY)
+                    tags = ts.to_list()
+                    # Create shapshot
+                    shortname = instance_name.split(".")[0]
+                    print(f"Creating snapshot of {device} ({volume.id}) on {shortname} ({i.id})")
+                    snapshot = volume.create_snapshot(
+                        Description=description,
+                        TagSpecifications=[{"ResourceType": "snapshot", "Tags": tags}],
+                    )
+                    snapshot_ids.append(snapshot.id)
+            # Wait for snapshots to complete
+            print(f"Waiting for {len(snapshot_ids)} snapshots to complete...")
+            waiter = self._ec2_client.get_waiter("snapshot_completed")
+            waiter.wait(
+                SnapshotIds=snapshot_ids,
+                WaiterConfig={
+                    "Delay": 5,
+                    "MaxAttempts": 720,
+                },
+            )
 
     def delete_snapshots(self, label: str) -> None:
         """
@@ -838,15 +842,16 @@ class ClusterSet:
             none
         """
         self._logger.debug("method_call: delete_snapshots")
-        snapshots = self.get_snapshots(label)
-        # Delete each snapshot
-        print(f"Deleting {len(snapshots)} snapshots...")
-        for snapshot in snapshots:
-            print(f"Deleting snapshot {snapshot.id}")
-            snapshot.delete()
-        # There is no waiter for snapshot deletion. Add a small delay to guard
-        # against any possible timing issues.
-        time.sleep(2)
+        with log_duration(self._logger, "delete_snapshots"):
+            snapshots = self.get_snapshots(label)
+            # Delete each snapshot
+            print(f"Deleting {len(snapshots)} snapshots...")
+            for snapshot in snapshots:
+                print(f"Deleting snapshot {snapshot.id}")
+                snapshot.delete()
+            # There is no waiter for snapshot deletion. Add a small delay to guard
+            # against any possible timing issues.
+            time.sleep(2)
 
     def tag_snapshots(self, tags: list[dict[str, str]]) -> None:
         snapshots = self.get_snapshots()
@@ -1062,74 +1067,74 @@ class ClusterSet:
             none
         """
         self._logger.debug("method_call: create_volumes_targeted")
+        with log_duration(self._logger, "create_volumes_targeted"):
+            # Validate regex pattern first
+            try:
+                pattern = re.compile(name_pattern)
+            except re.error as e:
+                raise ValueError(f"Invalid regex pattern '{name_pattern}': {e}") from e
 
-        # Validate regex pattern first
-        try:
-            pattern = re.compile(name_pattern)
-        except re.error as e:
-            raise ValueError(f"Invalid regex pattern '{name_pattern}': {e}") from e
+            snapshots = self.get_snapshots(label)
 
-        snapshots = self.get_snapshots(label)
+            # Check if snapshot list is empty
+            if len(snapshots) == 0:
+                print(f"Error: No snapshots found with label '{label}'.")
+                return
 
-        # Check if snapshot list is empty
-        if len(snapshots) == 0:
-            print(f"Error: No snapshots found with label '{label}'.")
-            return
+            # Filter snapshots by instance name pattern
+            targeted_snapshots = []
 
-        # Filter snapshots by instance name pattern
-        targeted_snapshots = []
+            for snapshot in snapshots:
+                ts = TagSet(snapshot.tags)
+                instance = ts.get("Instance")
+                if instance and pattern.search(instance):
+                    targeted_snapshots.append(snapshot)
 
-        for snapshot in snapshots:
-            ts = TagSet(snapshot.tags)
-            instance = ts.get("Instance")
-            if instance and pattern.search(instance):
-                targeted_snapshots.append(snapshot)
+            if len(targeted_snapshots) == 0:
+                print(f"No snapshots found for instances matching pattern '{name_pattern}'.")
+                return
 
-        if len(targeted_snapshots) == 0:
-            print(f"No snapshots found for instances matching pattern '{name_pattern}'.")
-            return
+            # Create volumes
+            volume_ids = []
+            for snapshot in targeted_snapshots:
+                ts = TagSet(snapshot.tags)
+                device = ts.get("Device")
+                instance = ts.get("Instance")
+                if not device:
+                    raise Exception(
+                        f"Error: create_volume: Can't find device tag for snapshot {snapshot.id}."
+                    )
+                if not instance:
+                    raise Exception(
+                        f"Error: create_volume: Can't find instance tag for snapshot {snapshot.id}."
+                    )
 
-        # Create volumes
-        volume_ids = []
-        for snapshot in targeted_snapshots:
-            ts = TagSet(snapshot.tags)
-            device = ts.get("Device")
-            instance = ts.get("Instance")
-            if not device:
-                raise Exception(
-                    f"Error: create_volume: Can't find device tag for snapshot {snapshot.id}."
+                # Determine availability zone from one of the cluster instances
+                avail_zone = self.get_instances()[0].placement["AvailabilityZone"]
+                # Make tags
+                ts = TagSet()
+                ts.add("Cluster", self._cluster_name_str)
+                ts.add("Device", device)
+                ts.add("Instance", instance)
+                ts.add("Label", label)
+                ts.add("Name", f"{instance} - {device}")
+                ts.add("automation_key", self.AUTOMATION_KEY)
+                tags = ts.to_list()
+                # Create volume
+                print(f"Creating volume from snapshot {snapshot.id} for {instance}")
+                volume = self._ec2.create_volume(
+                    SnapshotId=snapshot.id,
+                    AvailabilityZone=avail_zone,
+                    VolumeInitializationRate=300,
+                    TagSpecifications=[{"ResourceType": "volume", "Tags": tags}],
                 )
-            if not instance:
-                raise Exception(
-                    f"Error: create_volume: Can't find instance tag for snapshot {snapshot.id}."
-                )
+                volume_ids.append(volume.id)
 
-            # Determine availability zone from one of the cluster instances
-            avail_zone = self.get_instances()[0].placement["AvailabilityZone"]
-            # Make tags
-            ts = TagSet()
-            ts.add("Cluster", self._cluster_name_str)
-            ts.add("Device", device)
-            ts.add("Instance", instance)
-            ts.add("Label", label)
-            ts.add("Name", f"{instance} - {device}")
-            ts.add("automation_key", self.AUTOMATION_KEY)
-            tags = ts.to_list()
-            # Create volume
-            print(f"Creating volume from snapshot {snapshot.id} for {instance}")
-            volume = self._ec2.create_volume(
-                SnapshotId=snapshot.id,
-                AvailabilityZone=avail_zone,
-                VolumeInitializationRate=300,
-                TagSpecifications=[{"ResourceType": "volume", "Tags": tags}],
-            )
-            volume_ids.append(volume.id)
-
-        # Wait for the volumes to be created
-        if len(volume_ids) > 0:
-            print(f"Waiting for {len(volume_ids)} volumes to be created...")
-            self.wait_for_volumes(volume_ids, "volume_available")
-            self._wait_for_volume_tags(volume_ids)
+            # Wait for the volumes to be created
+            if len(volume_ids) > 0:
+                print(f"Waiting for {len(volume_ids)} volumes to be created...")
+                self.wait_for_volumes(volume_ids, "volume_available")
+                self._wait_for_volume_tags(volume_ids)
 
     def attach_volumes_targeted(self, label: str, name_pattern: str) -> None:
         """

--- a/src/tagmania/iac_tools/timing.py
+++ b/src/tagmania/iac_tools/timing.py
@@ -1,0 +1,23 @@
+"""Utilities for logging operation durations."""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+
+@contextmanager
+def log_duration(logger: logging.Logger, label: str) -> Iterator[None]:
+    """Log the wall-clock duration of the wrapped block at INFO level.
+
+    Emits the duration even if the wrapped block raises, so partial runs
+    still produce a timing line.
+    """
+    start = time.perf_counter()
+    try:
+        yield
+    finally:
+        elapsed = time.perf_counter() - start
+        logger.info(f"{label} took {elapsed:.1f}s")

--- a/src/tagmania/snapshot_manager.py
+++ b/src/tagmania/snapshot_manager.py
@@ -42,9 +42,22 @@ Warning:
 """
 
 import argparse
+import logging
 import re
 
 from tagmania.iac_tools.clusterset import ClusterSet
+from tagmania.iac_tools.timing import log_duration
+
+
+def _configure_logging() -> logging.Logger:
+    """Attach a stderr handler to the tagmania logger so INFO lines show up in the CLI."""
+    logger = logging.getLogger("tagmania")
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    return logger
 
 
 def main():
@@ -124,6 +137,7 @@ def main():
     parser.add_argument("--profile", "-p", help="the AWS profile to use", default=None)
     args = parser.parse_args()
 
+    logger = _configure_logging()
     cluster = ClusterSet(args.cluster, profile=args.profile)
 
     if args.backup:
@@ -135,11 +149,12 @@ def main():
             if len(instances) == 0:
                 print("No instances found. Operation aborted.")
             else:
-                # Stop the cluster (not clean)
-                cluster.stop_instances()
-                cluster.create_snapshots(snapshot_name)
-                # Start cluster
-                # cluster.start_instances()
+                with log_duration(logger, "backup"):
+                    # Stop the cluster (not clean)
+                    cluster.stop_instances()
+                    cluster.create_snapshots(snapshot_name)
+                    # Start cluster
+                    # cluster.start_instances()
                 print("Operation completed successfully!")
         else:
             print("Operation aborted.")
@@ -197,16 +212,17 @@ def main():
                     )
                     if confirm == "yes":
                         print("Restoring targeted instances.")
-                        # Stop targeted instances
-                        cluster.stop_instances_targeted(args.target)
-                        # Detach and delete volumes from targeted instances
-                        cluster.detach_volumes_targeted(args.target)
-                        cluster.delete_volumes_targeted(args.target)
-                        # Create new volumes from snapshots and attach them
-                        cluster.create_volumes_targeted(snapshot_name, args.target)
-                        cluster.attach_volumes_targeted(snapshot_name, args.target)
-                        # Start targeted instances
-                        # cluster.start_instances_targeted(args.target)
+                        with log_duration(logger, "restore_targeted"):
+                            # Stop targeted instances
+                            cluster.stop_instances_targeted(args.target)
+                            # Detach and delete volumes from targeted instances
+                            cluster.detach_volumes_targeted(args.target)
+                            cluster.delete_volumes_targeted(args.target)
+                            # Create new volumes from snapshots and attach them
+                            cluster.create_volumes_targeted(snapshot_name, args.target)
+                            cluster.attach_volumes_targeted(snapshot_name, args.target)
+                            # Start targeted instances
+                            # cluster.start_instances_targeted(args.target)
                         print("Operation completed successfully!")
                     else:
                         print("Operation aborted.")
@@ -222,16 +238,17 @@ def main():
                 if len(instances) == 0:
                     print("No instances found. Operation aborted.")
                 else:
-                    # Stop cluster (not clean)
-                    cluster.stop_instances()
-                    # Detach and delete current volumes
-                    cluster.detach_volumes()
-                    cluster.delete_volumes()
-                    # Create new volumes from snapshots and attach them
-                    cluster.create_volumes(snapshot_name)
-                    cluster.attach_volumes(snapshot_name)
-                    # Start cluster
-                    # cluster.start_instances()
+                    with log_duration(logger, "restore"):
+                        # Stop cluster (not clean)
+                        cluster.stop_instances()
+                        # Detach and delete current volumes
+                        cluster.detach_volumes()
+                        cluster.delete_volumes()
+                        # Create new volumes from snapshots and attach them
+                        cluster.create_volumes(snapshot_name)
+                        cluster.attach_volumes(snapshot_name)
+                        # Start cluster
+                        # cluster.start_instances()
                     print("Operation completed successfully!")
             else:
                 print("Operation aborted.")

--- a/tests/test_07_timing.py
+++ b/tests/test_07_timing.py
@@ -1,0 +1,38 @@
+import logging
+
+import pytest
+
+from tagmania.iac_tools.timing import log_duration
+
+
+class TestLogDuration:
+    def test_logs_label_and_duration_on_success(self, caplog):
+        logger = logging.getLogger("tagmania.test")
+        with caplog.at_level(logging.INFO, logger="tagmania.test"):
+            with log_duration(logger, "my_op"):
+                pass
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        assert record.levelno == logging.INFO
+        assert record.message.startswith("my_op took ")
+        assert record.message.endswith("s")
+
+    def test_logs_duration_when_block_raises(self, caplog):
+        logger = logging.getLogger("tagmania.test")
+        with caplog.at_level(logging.INFO, logger="tagmania.test"):
+            with pytest.raises(RuntimeError, match="boom"):
+                with log_duration(logger, "failing_op"):
+                    raise RuntimeError("boom")
+        assert len(caplog.records) == 1
+        assert caplog.records[0].message.startswith("failing_op took ")
+
+    def test_duration_reflects_elapsed_time(self, caplog):
+        logger = logging.getLogger("tagmania.test")
+        with caplog.at_level(logging.INFO, logger="tagmania.test"):
+            with log_duration(logger, "quick"):
+                pass
+        # Extract the duration value from "quick took 0.0s" (format is f"{elapsed:.1f}s")
+        message = caplog.records[0].message
+        duration_str = message.removeprefix("quick took ").removesuffix("s")
+        assert float(duration_str) >= 0.0
+        assert float(duration_str) < 1.0  # trivial block should take well under a second


### PR DESCRIPTION
## Summary

Closes #1.

- New `log_duration(logger, label)` context manager in `src/tagmania/iac_tools/timing.py` emits an INFO-level line like `create_snapshots took 127.4s` on exit (including on exception).
- Wraps `create_snapshots`, `create_volumes`, `create_volumes_targeted`, `delete_snapshots`, and `delete_volumes` in `ClusterSet`.
- Wraps the full backup, full restore, and targeted restore flows in `snapshot_manager` so users see the total wall-clock duration of the whole operation at the CLI level.
- Attaches a stderr StreamHandler to the `tagmania` logger on CLI startup so the INFO lines actually show up when running `cluster-snap`.
- Drive-by: renames a local `time` variable in `create_snapshots` that was shadowing the stdlib `time` module.

## Test plan

- [x] `uv run pytest tests/test_07_timing.py -v` -- 3 new unit tests for the context manager (success, exception path, duration format)
- [x] `uv run pytest -m "fast or (not slow and not integration)"` -- 90 unit tests pass
- [x] `uv run pre-commit run --all-files` -- clean
- [ ] Integration: run `cluster-snap --backup test1` and confirm `backup took Xs` and `create_snapshots took Xs` lines show up