### PR TITLE
docs: add IAM policy, architecture diagram, examples, and richer troubleshooting

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1,0 +1,113 @@
+# Tagmania Examples
+
+Real-world usage patterns. Each example assumes:
+
+- You have the [Minimum IAM Policy](README.md#minimum-iam-policy) attached to whatever AWS identity you're using.
+- Your EC2 instances carry a `Cluster` tag that matches the name you pass.
+- Your instance `Name` tags are set -- targeted restores and log output both depend on them.
+
+---
+
+## 1. Back up and restore a whole cluster
+
+Back up every attached EBS volume on every instance in a cluster, then restore from the same snapshot set later.
+
+```bash
+# Take a named snapshot of the whole cluster.
+# This stops instances first, snapshots all attached volumes, then leaves
+# instances stopped. Start them again with cluster-start.
+cluster-snap --backup --name pre-upgrade my-cluster
+
+# ... do risky work ...
+
+# Roll every volume back to the snapshot set. Again, leaves instances stopped.
+cluster-snap --restore --name pre-upgrade my-cluster
+cluster-start my-cluster
+```
+
+What happens during restore:
+
+1. Stop every instance in `my-cluster`.
+2. Detach every managed volume.
+3. Delete the detached volumes.
+4. Create fresh volumes from the snapshots tagged `Label=pre-upgrade`.
+5. Attach the new volumes back to their original instance + device.
+
+Instances stay stopped at the end -- you run `cluster-start` when you're ready to bring the cluster back up. This gives you a chance to verify volumes are attached correctly before boot.
+
+---
+
+## 2. Targeted restore with a regex
+
+Restore only a subset of the cluster -- handy when one service is misbehaving but you don't want to roll everything back.
+
+```bash
+# Roll back only the web tier. The regex matches against the Name tag.
+cluster-snap --restore --target ".*-web-.*" --name pre-upgrade my-cluster
+
+# Roll back a specific instance by exact name.
+cluster-snap --restore --target "my-cluster-db-01" --name pre-upgrade my-cluster
+```
+
+Common patterns:
+
+| Pattern | Matches |
+|---------|---------|
+| `".*-web-.*"` | any instance whose Name contains `-web-` |
+| `"worker-[0-9]+"` | `worker-1`, `worker-2`, ... |
+| `"prod-api-.*"` | every prod API box |
+| `"db-01"` | exactly the one DB box named `db-01` |
+
+The CLI prints the list of matched instances and asks for `yes` before touching anything.
+
+---
+
+## 3. Scheduled overnight snapshots via cron
+
+Back up a dev cluster every night, keeping only the last snapshot per label. Tagmania's `--backup --name X` overwrites any prior snapshot set that shares the same label, so you get one rolling snapshot per label without any extra bookkeeping.
+
+```bash
+# ~/.aws/credentials or an instance role must provide the AWS identity.
+# Example crontab entry -- nightly at 2am UTC:
+0 2 * * * /usr/local/bin/cluster-snap --backup --name nightly dev-cluster
+```
+
+Notes:
+
+- This replaces the `nightly` snapshot set every night -- you keep one-deep history.
+- To keep a week of rolling history, schedule seven jobs with day-of-week labels:
+
+  ```cron
+  0 2 * * 0 /usr/local/bin/cluster-snap --backup --name sun dev-cluster
+  0 2 * * 1 /usr/local/bin/cluster-snap --backup --name mon dev-cluster
+  # ... through Saturday
+  ```
+
+- `cluster-snap --backup` stops instances before snapshotting. For a dev cluster that's usually fine. For a production cluster, plan maintenance windows around this.
+
+---
+
+## 4. Cross-region snapshots -- what doesn't work
+
+Tagmania operates within whatever region the AWS CLI profile points to. **EBS snapshots are region-scoped**, and Tagmania does not copy snapshots across regions.
+
+If you need cross-region disaster-recovery copies, do the copy yourself with the AWS CLI after Tagmania runs:
+
+```bash
+# Take snapshots in the primary region.
+cluster-snap --backup --name dr-primary my-cluster --profile us-east-1
+
+# Use aws ec2 copy-snapshot to replicate each snapshot to the DR region.
+# Tagmania's snapshots carry automation_key=SNAPSHOT_MANAGER and
+# Label=dr-primary, so you can filter to just the ones you care about:
+aws --profile us-east-1 ec2 describe-snapshots \
+  --filters "Name=tag:automation_key,Values=SNAPSHOT_MANAGER" \
+            "Name=tag:Label,Values=dr-primary" \
+  --query 'Snapshots[].SnapshotId' --output text \
+  | xargs -n1 -I{} aws --profile us-east-1 ec2 copy-snapshot \
+      --source-region us-east-1 \
+      --destination-region us-west-2 \
+      --source-snapshot-id {}
+```
+
+Restoring in the DR region would require creating a matching cluster there (same `Cluster` tag), then manually attaching volumes created from the copied snapshots -- Tagmania's restore assumes the source snapshots live in the same region as the target cluster.

--- a/README.md
+++ b/README.md
@@ -41,11 +41,10 @@ It operates only on resources it's been told to manage (via a `SNAPSHOT_MANAGER`
 
 ### Prerequisites
 
-- Python 3.12 or higher
-- An AWS account with EC2 access
-- An AWS CLI profile configured (e.g. via `aws configure`)
-- EC2 instances tagged with a `Cluster` tag identifying their membership
-- IAM permissions for the `ec2:*` actions listed in the [template IAM policy](template.yaml) (read + start/stop + snapshot/volume lifecycle)
+- **Python 3.12 or higher** (`python --version`)
+- **AWS CLI profile** configured via `aws configure` or `~/.aws/credentials`
+- **EC2 instances tagged** with a `Cluster` tag identifying their membership
+- **IAM permissions** -- see [Minimum IAM Policy](#minimum-iam-policy) below
 
 ### First-time setup
 
@@ -71,7 +70,78 @@ cluster-snap --restore my-cluster         # restore volumes from most recent sna
 cluster-snap --list    my-cluster         # list snapshots for the cluster
 ```
 
-All commands accept `--profile <aws-profile>` for credential selection. See [Available Commands](#available-commands) and [Advanced Features](#advanced-features) below for more.
+All commands accept `--profile <aws-profile>` for credential selection. See [Available Commands](#available-commands) and [Advanced Features](#advanced-features) below for more. Additional end-to-end walkthroughs live in [EXAMPLES.md](EXAMPLES.md).
+
+### Minimum IAM Policy
+
+The AWS identity running Tagmania needs the following permissions. Replace `my-cluster` with your actual `Cluster` tag value (or use a wildcard list if you manage multiple clusters).
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "EC2Read",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeInstances",
+        "ec2:DescribeSnapshots",
+        "ec2:DescribeVolumes",
+        "ec2:DescribeImages",
+        "ec2:DescribeAvailabilityZones"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "InstanceStartStop",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:StartInstances",
+        "ec2:StopInstances"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": { "ec2:ResourceTag/Cluster": ["my-cluster"] }
+      }
+    },
+    {
+      "Sid": "VolumeLifecycleTagged",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteVolume",
+        "ec2:AttachVolume",
+        "ec2:DetachVolume",
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": { "ec2:ResourceTag/Cluster": ["my-cluster"] }
+      }
+    },
+    {
+      "Sid": "VolumeCreate",
+      "Effect": "Allow",
+      "Action": ["ec2:CreateVolume"],
+      "Resource": "*"
+    },
+    {
+      "Sid": "SnapshotLifecycle",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateSnapshot",
+        "ec2:DeleteSnapshot",
+        "ec2:CreateTags"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+The tagged conditions restrict the blast radius of start/stop and volume-modifying calls to instances that carry the matching `Cluster` tag. `CreateVolume` and snapshot create/delete are not tag-conditioned because AWS doesn't support that tag condition during resource creation.
+
+The `template.yaml` in this repo uses the same policy shape for integration-test infrastructure.
 
 ---
 
@@ -92,6 +162,34 @@ All commands accept `--profile <aws-profile>` for credential selection. See [Ava
 5. **Merge** once CI is green.
 
 If you need to work manually, see the full [contributor guide](CONTRIBUTING.md).
+
+---
+
+## Architecture
+
+Tagmania is a thin layer on top of `boto3`. Every CLI entry point instantiates a `ClusterSet`, which owns an EC2 resource + client and exposes tag-scoped operations on instances, volumes, and snapshots.
+
+```mermaid
+flowchart LR
+    CLI["CLI entry points<br/>cluster-start / cluster-stop / cluster-snap"]
+    CS["ClusterSet<br/>(src/tagmania/iac_tools/clusterset.py)"]
+    subgraph boto3[boto3]
+      EC2R["EC2 resource"]
+      EC2C["EC2 client"]
+    end
+    TS["TagSet<br/>[{Key, Value}, ...]"]
+    FS["FilterSet<br/>[{Name, Values}, ...]"]
+
+    CLI --> CS
+    CS --> EC2R
+    CS --> EC2C
+    CS --> TS
+    CS --> FS
+```
+
+- **ClusterSet** is the only class that issues AWS API calls. It enforces a `_MAX_ITEMS = 150` safety cap and only touches resources tagged with its `AUTOMATION_KEY = "SNAPSHOT_MANAGER"`.
+- **TagSet** and **FilterSet** are tiny wrappers around the two shapes of list-of-dicts that AWS uses (`[{Key, Value}]` for tags, `[{Name, Values}]` for filters).
+- **Snapshot / volume lifecycles** run sequentially inside `ClusterSet.create_snapshots` and `create_volumes`. Targeted variants (`*_targeted`) filter by regex against the instance `Name` tag for partial cluster operations.
 
 ---
 
@@ -279,11 +377,12 @@ pip install tagmania==2.5.0
 
 ## Troubleshooting
 
-- **No instances found**: Verify "Cluster" tag exists and matches exactly
-- **Invalid regex**: Test regex patterns before using with targeted operations
-- **Permission errors**: Ensure AWS profile has EC2 and EBS permissions
-- **Timeout issues**: Large volumes may take time to snapshot/restore
-- **Python compatibility**: Requires Python 3.12 or higher
+- **`No instances found`**: The `Cluster` tag doesn't match any running or stopped instance. Tags are case-sensitive; verify with `aws ec2 describe-instances --filters Name=tag:Cluster,Values=my-cluster`.
+- **`UnauthorizedOperation` / `AccessDenied`**: The AWS identity is missing one of the required permissions. See the [Minimum IAM Policy](#minimum-iam-policy) -- most permission errors come from the conditioned `ec2:StartInstances` / `ec2:StopInstances` / volume actions when the caller's `Cluster` tag restriction doesn't include the cluster you're operating on.
+- **`Invalid regex pattern`**: Targeted restore (`--target`) validates its regex before running. Test patterns with a quick `--list` or `python -c "import re; re.compile('...')"` before passing to `--restore`.
+- **Snapshot completes but restore hangs**: Large EBS volumes (>1TB) can exceed the default 60-minute waiter timeout. The waiter polls every 5s for up to 720 attempts; watch the log for the `create_snapshots took Xs` timing line to gauge duration.
+- **`InvalidSnapshot.NotFound`**: The snapshot label doesn't exist for this cluster. List labels with `cluster-snap --list my-cluster`.
+- **Python compatibility**: Requires Python 3.12 or higher (see `pyproject.toml`).
 
 ## Support
 


### PR DESCRIPTION
## Summary

Closes #5.

Stacked on top of #21 so the documentation changes layer cleanly on the standardized README skeleton. When #21 merges into main, GitHub will auto-retarget this PR's base to main.

### README

- **Minimum IAM Policy** -- a JSON block (adapted from `template.yaml`) showing the exact `ec2:*` actions Tagmania needs. Tag-condition the destructive actions by `Cluster` so the blast radius is scoped. This was the single biggest doc gap for new users.
- **Architecture** -- a mermaid diagram of CLI -> ClusterSet -> boto3, plus short prose on the role of TagSet/FilterSet and the `_MAX_ITEMS`/`AUTOMATION_KEY` safety features.
- **Troubleshooting** -- replaced vague bullets with concrete error strings (`UnauthorizedOperation`, `InvalidSnapshot.NotFound`, `Invalid regex`) and linked permission errors back to the IAM policy section. Updated the Python version note to match pyproject (3.12+).
- **Prerequisites** -- tightened and now links to the IAM policy section.

### EXAMPLES.md (new)

Four scenarios:

1. Full cluster backup + restore
2. Targeted restore with a regex
3. Scheduled overnight snapshots via cron (and a rolling-week variant)
4. Cross-region limitations and an `aws ec2 copy-snapshot` workaround

## Test plan

- [ ] Render README and EXAMPLES.md on GitHub and confirm mermaid diagram renders + all cross-links resolve
- [ ] IAM policy JSON is copy-pasteable and validates (e.g. via `aws iam create-policy --policy-document`)