### PR TITLE
docs: add CODE_OF_CONDUCT.md and SUPPORT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,13 @@
+# Code of Conduct
+
+This project follows the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+By participating in this project you agree to abide by its terms.
+
+## Reporting
+
+If you experience or witness unacceptable behavior, please report it by
+opening a [GitHub issue](https://github.com/svange/tagmania/issues) or
+emailing the maintainer directly.
+
+All reports will be reviewed and investigated.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,15 @@
+# Support
+
+## How to get help
+
+| Channel | Use for |
+|---------|---------|
+| [GitHub Issues](https://github.com/svange/tagmania/issues) | Bug reports and feature requests |
+| [GitHub Discussions](https://github.com/svange/tagmania/discussions) | Questions, ideas, and general conversation |
+| [Security Policy](.github/SECURITY.md) | Reporting security vulnerabilities (coordinated disclosure) |
+
+## Before opening an issue
+
+1. Check existing [open issues](https://github.com/svange/tagmania/issues) to avoid duplicates.
+2. Include your Tagmania version (`pip show tagmania`), Python version, and the full error output.
+3. For permission errors, compare your IAM policy against the [minimum IAM policy](README.md#minimum-iam-policy) in the README.


### PR DESCRIPTION
## Summary

Closes #6 (trimmed scope per triage).

- **CODE_OF_CONDUCT.md** -- references Contributor Covenant v2.1 (already cited in CONTRIBUTING.md). Kept short; links to the full text rather than embedding it.
- **SUPPORT.md** -- routes users to Issues (bugs), Discussions (questions), and the security policy (vulnerabilities). Includes a "before opening an issue" checklist referencing the IAM policy docs from #5.

Intentionally **not** adding:
- GOVERNANCE.md (solo-maintainer project)
- Response-time SLAs

## Test plan

- [ ] CODE_OF_CONDUCT.md and SUPPORT.md render on GitHub
- [ ] GitHub Community Standards page shows both as present