### PR TITLE
ci: fix cleanup stack waiter and scope env gate to deploy only

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -371,12 +371,6 @@ jobs:
     concurrency:
       group: testing-stack-${{ github.repository }}
       cancel-in-progress: false
-    # Maintainer bypass of the approval-required environment is disabled so
-    # we can exercise the environment approval flow end-to-end. To restore
-    # the bypass (repo owner / MAINTAINERS list skip the manual approval
-    # gate; push events run unattended), replace the line below with:
-    #   environment: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login != github.repository_owner && !contains(fromJSON(vars.MAINTAINERS || '[]'), github.event.pull_request.user.login) && 'approval-required' || '' }}
-    environment: approval-required
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -440,13 +434,11 @@ jobs:
     concurrency:
       group: testing-stack-${{ github.repository }}
       cancel-in-progress: false
-    # Maintainer bypass of the approval-required environment is disabled so
-    # we can exercise the environment approval flow end-to-end. To restore
-    # the bypass (repo owner / MAINTAINERS list skip the manual approval
-    # gate; push events run unattended), replace the line below with:
-    #   environment: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login != github.repository_owner && !contains(fromJSON(vars.MAINTAINERS || '[]'), github.event.pull_request.user.login) && 'approval-required' || '' }}
-    environment: approval-required
     runs-on: ubuntu-latest
+    # Cleanup is best-effort: failures show red on this job but do not
+    # fail the workflow. Investigate red cleanup jobs -- usually a test
+    # template change or a terminal CloudFormation state.
+    continue-on-error: true
     permissions:
       id-token: write
       contents: read
@@ -472,9 +464,7 @@ jobs:
           echo "Waiting for stack deletion to complete..."
           aws cloudformation wait stack-delete-complete \
             --stack-name "${TESTING_STACK_NAME}" \
-            --region "${TESTING_REGION}" \
-            --waiter-delay 30 \
-            --waiter-attempts 120
+            --region "${TESTING_REGION}"
 
           echo "Stack ${TESTING_STACK_NAME} successfully deleted"
 


### PR DESCRIPTION
## Summary
Follow-up to #27, which shipped two issues to main:

1. **Invalid waiter flags** — `aws cloudformation wait stack-delete-complete` does not accept `--waiter-delay` or `--waiter-attempts`. The command was exiting 252 immediately; no wait ever happened. The step-level `continue-on-error: true` masked this for months. Removing those flags; the defaults (30s × 120 attempts = 60 min) match the intent.
2. **Over-broad environment gate** — gating acceptance-tests and cleanup on `approval-required` is wrong. Only `deploy-test-infrastructure` should require approval. Tests run after deploy is approved; cleanup must always run so the stack doesn't leak.

Plus one behavior change so cleanup failures are visible without gating anything:

3. **`continue-on-error: true` at the job level** on cleanup-test-infrastructure. Step failures still turn the job tile red (visible signal), but the workflow run stays green so merge and release are unaffected.

## Test plan
- [ ] Pipeline reaches `Deploy test infrastructure`, pauses on approval-required environment, runs after approval
- [ ] `Acceptance tests` runs unattended after deploy
- [ ] `Cleanup test infrastructure` runs unattended, `aws cloudformation wait stack-delete-complete` returns successfully
- [ ] Workflow run reports green overall
- [ ] If cleanup is manually broken (e.g. by editing the waiter call), verify the job shows red while the workflow stays green