### PR TITLE
test: trigger pipeline to validate env approval gate

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -293,6 +293,8 @@ jobs:
           path: test-report.html
 
   deploy-test-infrastructure:
+    # Gated on the `approval-required` GitHub Environment. Reviewers and
+    # admin-bypass policy live in repo Settings -> Environments, not here.
     name: Deploy test infrastructure
     runs-on: ubuntu-latest
     needs: [security, compliance, build-validation, unit-tests]


### PR DESCRIPTION
## Purpose
Trigger a pipeline run now that the \`approval-required\` environment has actual protection rules configured. Watching for \`Deploy test infrastructure\` to enter "Waiting" state and notify for review.

## Expected flow
1. Pre-deploy gates run unattended (\~1 min)
2. \`Deploy test infrastructure\` → **Waiting for review** (you should get a GitHub notification + email, and see an "Approve and deploy" banner in the Actions UI)
3. You approve → deploy runs
4. Acceptance tests (echo-only, thanks to #29) → seconds
5. Cleanup → ~30s
6. Automerge lands the PR

If deploy runs without pausing, the environment is still misconfigured.

## Content change
Small comment on \`deploy-test-infrastructure\` documenting that the gate lives in repo Settings → Environments. Purely informational.