### PR TITLE
chore: complete ai-cc-tools standardization

### DIFF
--- a/.ai-compliance.yaml
+++ b/.ai-compliance.yaml
@@ -4,50 +4,79 @@
 #
 # The engine lives in augint-tools (TUI dashboard) and evaluates the rules in
 # ai-cc-tools' canonical standards.yaml against this repo on every dashboard
-# refresh. By default every rule applies -- uncomment sections below to opt
-# out or override params for this repo specifically.
+# refresh. By default every rule applies -- add entries below to opt out or
+# override params for this repo specifically.
 #
 # Opt-outs are visible in the dashboard (the engine emits an OK finding with
-# "disabled by .ai-compliance.yaml" so coverage reductions stay auditable).
-# Edits take effect on the next dashboard refresh; no deploy or restart.
+# "disabled by .ai-compliance.yaml" plus the reason, so coverage reductions
+# stay auditable). Edits take effect on the next dashboard refresh.
 #
-# Source of truth for valid check IDs (canonical severity, rationale, etc.):
+# Source of truth for valid check IDs:
 #   https://github.com/augmenting-integrations/ai-cc-tools/blob/main/plugins/ai-standardize/standards.yaml
 # =============================================================================
 
 # -----------------------------------------------------------------------------
+# metadata
+# -----------------------------------------------------------------------------
+# Tracks which standards version this repo was last standardized against.
+# Updated automatically by /ai-standardize-compliance.
+metadata:
+  standards_version: "2026-04-22"
+  last_standardized: "2026-04-23"
+  last_standardized_by: "7166607+svange@users.noreply.github.com"
+
+# -----------------------------------------------------------------------------
 # disabled_checks
 # -----------------------------------------------------------------------------
-# List of check IDs to skip for this repo. Default is empty -- every
-# applicable rule runs.
+# List of checks to skip for this repo. Each entry requires an id, reason,
+# created_at date, and approved_by email. The reason field is surfaced in the
+# dashboard and provides AI agents with context for related decisions.
 disabled_checks: []
 
 # Examples (uncomment and edit as needed):
 #
 # disabled_checks:
-#   - deploy.health_probe              # Repo has no public prod URL yet
-#   - deploy.lambda_sha_matches_main   # Deployed via CDK stack, not Lambda
-#   - security.npm_audit_high          # Python-only repo, no package.json
+#   - id: deploy.health_probe
+#     reason: "Repo has no public prod URL yet"
+#     created_at: 2026-04-23
+#     approved_by: "dev@example.com"
+#   - id: deploy.lambda_sha_matches_main
+#     reason: "Deployed via CDK stack, not standalone Lambda"
+#     created_at: 2026-04-23
+#     approved_by: "dev@example.com"
+#   - id: security.npm_audit_high
+#     reason: "Python-only repo, no package.json"
+#     created_at: 2026-04-23
+#     approved_by: "dev@example.com"
 
 # -----------------------------------------------------------------------------
 # overrides
 # -----------------------------------------------------------------------------
-# Per-check parameter overrides, merged into the check's params before
-# evaluation. Common for handler-based checks that need repo-specific values
-# (real prod URL, custom IAM role naming, non-default tag key, etc.).
+# Per-check parameter overrides merged into the check's params before
+# evaluation. Include reason, created_at, and approved_by alongside the
+# check-specific parameters. Metadata keys are stripped before evaluation.
 overrides: {}
 
 # Examples:
 #
 # overrides:
 #   deploy.health_probe:
+#     reason: "Custom health endpoint path"
+#     created_at: 2026-04-23
+#     approved_by: "dev@example.com"
 #     url: "https://api.my-service.example.com/health"
 #     expected_status: 204
 #     timeout_seconds: 10
 #
 #   deploy.oidc_trust_scoped:
-#     role_name_template: "{repo_name}-github-deploy"  # non-default naming
+#     reason: "Non-default IAM role naming convention"
+#     created_at: 2026-04-23
+#     approved_by: "dev@example.com"
+#     role_name_template: "{repo_name}-github-deploy"
 #
 #   deploy.lambda_sha_matches_main:
+#     reason: "Non-default function naming"
+#     created_at: 2026-04-23
+#     approved_by: "dev@example.com"
 #     function_name_template: "prod-{repo_name}-api"
-#     tag_key: "git_commit"  # if your deploy tags with a different key
+#     tag_key: "git_commit"

--- a/.github/workflows/cve-review.yaml
+++ b/.github/workflows/cve-review.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Collect current ignores
         id: ignores
         run: |
-          LIST=$(grep 'ignore-vuln' .github/workflows/pipeline.yaml \
+          LIST=$(grep 'ignore-vuln' .github/workflows/publish.yaml \
             | sed 's/.*--ignore-vuln /- /' | sort)
           echo "list<<EOF" >> "$GITHUB_OUTPUT"
           echo "$LIST" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,12 +4,10 @@ on:
   pull_request:
     branches:
       - main
-      - dev
     types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:
       - main
-      - dev
 
 env:
   TESTING_REGION: ${{ vars.TESTING_REGION }}
@@ -26,8 +24,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   code-quality:
@@ -85,10 +83,10 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen --all-extras
 
-      - name: Run Bandit security scan
-        run: |
-          uv run bandit -r src/ -f json -o bandit-report.json || true
-          uv run bandit -r src/ -ll
+      - name: Bandit
+        # Single invocation: -ll enforces medium+ severity (exit code),
+        # -f json -o writes the artifact for the upload step below.
+        run: uv run bandit -r src/ -ll -f json -o bandit-report.json
 
       - name: Run pip-audit
         run: |
@@ -113,67 +111,18 @@ jobs:
           uv run checkov \
             --quiet \
             --download-external-modules false \
-            --framework cloudformation,serverless \
+            --framework cloudformation,serverless,cdk \
             --skip-check CKV_AWS_23,CKV_AWS_111 \
             --directory .
 
-      - name: Generate security HTML report
-        if: always()
-        run: |
-          cat > security-reports.html << 'EOF'
-          <!DOCTYPE html>
-          <html>
-          <head>
-              <title>Security Scan Results</title>
-              <style>
-                  body { font-family: Arial, sans-serif; margin: 20px; background: #0d1117; color: #c9d1d9; }
-                  .report { margin: 20px 0; padding: 15px; border: 1px solid #30363d; border-radius: 8px; background: #161b22; }
-                  .report h2 { color: #58a6ff; margin-top: 0; }
-                  pre { background: #0d1117; padding: 10px; border-radius: 4px; overflow-x: auto; border: 1px solid #30363d; font-size: 12px; }
-                  .error { color: #ff7b72; }
-                  .warning { color: #ffa657; }
-                  .info { color: #79c0ff; }
-              </style>
-          </head>
-          <body>
-              <h1>Security Scan Results</h1>
-              <div class="report">
-                  <h2>Bandit Security Scan</h2>
-                  <pre id="bandit-content"></pre>
-              </div>
-              <div class="report">
-                  <h2>Pip-Audit Results</h2>
-                  <pre id="audit-content"></pre>
-              </div>
-              <script>
-                  const reports = [
-                      {id: 'bandit-content', file: 'bandit-report.json'},
-                      {id: 'audit-content', file: 'pip-audit-report.json'}
-                  ];
-                  reports.forEach(report => {
-                      fetch(report.file)
-                          .then(response => response.json())
-                          .then(data => {
-                              document.getElementById(report.id).textContent = JSON.stringify(data, null, 2);
-                          })
-                          .catch(error => {
-                              document.getElementById(report.id).textContent = 'Report not available';
-                          });
-                  });
-              </script>
-          </body>
-          </html>
-          EOF
-
-      - name: Upload security scan results
+      - name: Upload security reports
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: security-scan-results
+          name: security-reports
           path: |
             bandit-report.json
             pip-audit-report.json
-            security-reports.html
 
   compliance:
     name: Compliance
@@ -296,7 +245,7 @@ jobs:
     if: |
       vars.TESTING_PIPELINE_EXECUTION_ROLE != '' &&
       (
-        (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')) ||
+        (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
         (github.event_name == 'pull_request' && !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository)
       )
     concurrency:
@@ -360,7 +309,7 @@ jobs:
     if: |
       vars.TESTING_PIPELINE_EXECUTION_ROLE != '' &&
       (
-        (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')) ||
+        (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
         (github.event_name == 'pull_request' && !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository)
       )
     concurrency:
@@ -466,7 +415,7 @@ jobs:
   release:
     name: Semantic release
     needs: [unit-tests, acceptance-tests, security, compliance, build-validation]
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-release-${{ github.ref_name }}
@@ -621,10 +570,10 @@ jobs:
           path: docs/coverage
         continue-on-error: true
 
-      - name: Download security scan results
+      - name: Download security reports
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: security-scan-results
+          name: security-reports
           path: docs/security
         continue-on-error: true
 

--- a/.gitignore
+++ b/.gitignore
@@ -15,12 +15,10 @@
 
 # === Claude Code / AI Tool History ===
 .claude/settings.local.json
-.claude/plans/
 **/.claude/worktrees/
 .aider.chat.history.md
 .aider.input.history
 .aider/
-.serena
 
 # === Python ===
 __pycache__/
@@ -88,11 +86,9 @@ out/
 storybook-static/
 
 # === AWS SAM ===
-samconfig.toml
 samconfig.toml.local
 packaged.yaml
 packaged.yml
-packaged-testing.yaml
 layers/dependencies/python/
 layers/*/python/
 .sam-build/
@@ -119,8 +115,6 @@ logs/
 playwright-report/
 blob-report/
 .playwright/
-test-report.html
-pytest.log
 
 # === Security / Compliance Reports ===
 bandit-report.json
@@ -161,11 +155,24 @@ Thumbs.db
 tmp/
 temp/
 
-# === Generated Docs ===
+# === Custom (preserved from previous version) ===
+
+# AI tool artifacts
+.claude/plans/
+.serena
+
+# AWS SAM (repo-specific)
+samconfig.toml
+
+# Test artifacts
+test-report.html
+pytest.log
+
+# Generated docs (pdoc output)
 docs/
 
-# === Generated Reports ===
+# Generated reports
 report.html
 
-# === Reference repos ===
+# Reference repos (sibling checkout)
 ai-lls-lib/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ Full restore: stop instances -> detach volumes -> delete volumes -> create volum
 
 ## CI/CD Pipeline
 
-GitHub Actions pipeline (`.github/workflows/pipeline.yaml`) gates by canonical stage names:
+GitHub Actions pipeline (`.github/workflows/publish.yaml`) gates by canonical stage names:
 
 ### Pre-deploy gates (run on both PR and push, no AWS required)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tagmania
 
-[![CI Status](https://github.com/svange/tagmania/actions/workflows/pipeline.yaml/badge.svg?branch=main)](https://github.com/svange/tagmania/actions/workflows/pipeline.yaml)
+[![CI Status](https://github.com/svange/tagmania/actions/workflows/publish.yaml/badge.svg?branch=main)](https://github.com/svange/tagmania/actions/workflows/publish.yaml)
 [![PyPI](https://img.shields.io/pypi/v/tagmania?style=flat-square)](https://pypi.org/project/tagmania/)
 [![semantic-release](https://img.shields.io/badge/%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg?style=flat-square)](https://github.com/semantic-release/semantic-release)
 [![License](https://img.shields.io/github/license/svange/tagmania?style=flat-square)](https://github.com/svange/tagmania/blob/main/LICENSE)
@@ -17,8 +17,7 @@ Manic tools for manipulating sets of tagged resources in AWS.
 |--------|------|
 | API Documentation | [svange.github.io/tagmania](https://svange.github.io/tagmania/) |
 | Test Report | [tests/test-report.html](https://svange.github.io/tagmania/tests/test-report.html) |
-| Coverage Report | [coverage/](https://svange.github.io/tagmania/coverage/) |
-| Security Scan | [security/security-reports.html](https://svange.github.io/tagmania/security/security-reports.html) |
+| Coverage Report | [coverage/htmlcov/](https://svange.github.io/tagmania/coverage/htmlcov/) |
 | License Compliance | [compliance/license-report.html](https://svange.github.io/tagmania/compliance/license-report.html) |
 | PyPI | [pypi.org/project/tagmania](https://pypi.org/project/tagmania/) |
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -13,8 +13,10 @@
   "schedule": ["before 11:59pm on Sunday"],
   "timezone": "America/Los_Angeles",
   "platformAutomerge": true,
-  // "auto" defers to repo merge method settings
-  "automergeStrategy": "auto",
+  // "merge-commit" ensures Renovate PRs preserve individual commit messages
+  // through dev->main promotion. "auto" or "squash" would drop semantic-release
+  // commit markers, breaking the release cycle.
+  "automergeStrategy": "merge-commit",
   "rangeStrategy": "auto",
 
   "enabledManagers": [


### PR DESCRIPTION
## Summary

Finalizes the ai-cc-tools canonical-contract standardization started in 2cb57d7, and completes the parts not covered by that earlier pass.

### Content changes
- Rename `pipeline.yaml` -> `publish.yaml` (canonical filename for library repos). PyPI Trusted Publisher config already updated.
- Canonical concurrency block on the workflow: cancel stale PR runs, keep push/deploy runs running.
- Security job aligned to canonical: dropped the custom HTML report, renamed artifact to `security-reports`, single-invocation Bandit, `cdk` added to checkov frameworks. `docs` job updated to match.
- Dev-branch triggers and conditions removed from the workflow. Library is main-only; there is no `origin/dev`.
- `.ai-compliance.yaml` re-created with canonical metadata (standards_version `2026-04-22`).
- `renovate.json5` `automergeStrategy` flipped from `auto` -> `merge-commit`. `auto` can resolve to squash, which drops semantic-release commit markers through dev->main promotion.
- `.gitignore` restructured with the 7 repo-specific entries preserved under an explicit marker block.
- README CI badge URL updated to `publish.yaml`. Artifact table realigned to the actual gh-pages layout: coverage link now points to `coverage/htmlcov/`, and the broken `security-reports.html` row removed (HTML generation is gone).
- `CLAUDE.md` and `cve-review.yaml` updated to reference `publish.yaml`.

### Remote changes (already applied via `gh api`, not in this diff)
- Ruleset `Publishing Branches`: added Maintain role (actor_id 4) to `bypass_actors`, removed `refs/heads/dev` from `conditions.include`. Final state: 2 bypass actors (Maintain + Admin), `include = [~DEFAULT_BRANCH]`, 4 rules, 6 required status checks including Acceptance tests.
- OIDC verified: org StackSet wildcard `repo:svange/*` pattern covers both required subjects (`ref:refs/heads/main` and `environment:approval-required`). No changes needed.

### What was already canonical (audited, no changes)
`.editorconfig`, `.pre-commit-config.yaml` (15 hooks, python-with-sam variant), `[tool.semantic_release]` (exact match), `[tool.coverage.report] fail_under=80`, `.github/CODEOWNERS`, repo merge/automerge/delete-branch settings.

## Test plan
- [ ] Pre-commit passes locally (confirmed)
- [ ] Pipeline Code quality, Security, Unit tests, Compliance, Build validation pass
- [ ] Acceptance tests pass (runs against real AWS via TESTING_PIPELINE_EXECUTION_ROLE)
- [ ] Next feat/fix on main triggers release -> publish-to-pypi -> docs, validating PyPI Trusted Publisher config update

## Follow-ups (not in this PR)
- None expected. All flagged drift either resolved or preserved as intentional.