### PR TITLE
chore: polish cluster start/stop CLI log messages

### DIFF
--- a/src/tagmania/start_cluster.py
+++ b/src/tagmania/start_cluster.py
@@ -66,7 +66,7 @@ def main():
 
     cluster = ClusterSet(args.cluster, profile=args.profile)
     cluster.start_instances()
-    print(f"Cluster {cluster.cluster_names} started!")
+    print(f"Cluster {cluster.cluster_names} started successfully.")
 
 
 if __name__ == "__main__":

--- a/src/tagmania/stop_cluster.py
+++ b/src/tagmania/stop_cluster.py
@@ -70,7 +70,7 @@ def main():
 
     cluster = ClusterSet(args.cluster, profile=args.profile)
     cluster.stop_instances()
-    print(f"Cluster {cluster.cluster_names} stopped!")
+    print(f"Cluster {cluster.cluster_names} stopped successfully.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Log-only cosmetic change. CLI messages in `cluster-start` and `cluster-stop` now read "started successfully." / "stopped successfully." instead of "started!" / "stopped!". No functional change.

## Purpose

Validates the OIDC trust-policy fix applied to `SAMDeployRole` (added `repo:svange/*:pull_request` subject). Prior to the fix, owner-PR runs failed `Configure AWS credentials` in `Deploy test infrastructure` because the env-approval gate evaluated to an empty environment for repo-owner, producing an unmatched `pull_request` OIDC claim. This PR is the first owner-PR after that trust-policy patch, so it proves the full gate sequence runs on PR events, not just on push.

## Test plan
- [ ] Pre-merge gates pass (Code quality, Security, Unit tests, Compliance, Build validation) -- confirmed locally
- [ ] `Deploy test infrastructure` succeeds on PR trigger (previously failed at Configure AWS credentials)
- [ ] `Acceptance tests` runs against the deployed test fixture and passes
- [ ] `Cleanup test infrastructure` succeeds
- [ ] No release is triggered (chore commit; semantic-release stays idle)