### PR TITLE
ci: scope GH_TOKEN to release step and pin setup-sam digest

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,7 +15,6 @@ env:
   TESTING_CLOUDFORMATION_EXECUTION_ROLE: ${{ vars.TESTING_CLOUDFORMATION_EXECUTION_ROLE }}
   TESTING_PIPELINE_EXECUTION_ROLE: ${{ vars.TESTING_PIPELINE_EXECUTION_ROLE }}
   AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
   MODULE_NAME: ${{ vars.MODULE_NAME }}
   PYTHON_VERSION: ${{ vars.PYTHON_VERSION || '3.12' }}
   TESTING_STACK_NAME: ${{ github.event.repository.name }}-testing
@@ -274,7 +273,7 @@ jobs:
 
       - name: Set up SAM CLI
         if: steps.check_template.outputs.exists == 'true'
-        uses: aws-actions/setup-sam@v2
+        uses: aws-actions/setup-sam@f84ec7d548307efafe33230528756de3c5841a17 # v2
         with:
           use-installer: true
 
@@ -477,6 +476,8 @@ jobs:
 
       - name: Run semantic release
         id: release
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           RELEASED="false"
 


### PR DESCRIPTION
## 🚀 Summary

Fixes the two blocking Semgrep findings (`p/security-audit`) that were failing the **Security** gate on every PR and push to `main` — the reason the three merged Renovate PRs went red in CI:

- **`gha-workflow-env-secret`** — `GH_TOKEN` lived in the workflow-level `env:` block, exposing the secret to every job and step. Moved it to a **step-level `env:`** on the `Run semantic release` step, the only consumer of `$GH_TOKEN`. The checkout and docs-deploy steps already reference `secrets.GH_TOKEN` directly via `with:` inputs, so nothing else needs it.
- **`github-actions-mutable-action-tag`** — `aws-actions/setup-sam@v2` was the last action still on a mutable tag. Pinned it to the `v2` commit digest (`@f84ec7d… # v2`), matching the `@<sha> # <version>` convention Renovate already maintains for every other action via `helpers:pinGitHubActionDigestsToSemver`.

### Renovate compatibility

This is **not** a permanent pin. `setup-sam` only publishes rolling major tags (`v0`–`v3`), which is exactly why Renovate's digest-to-semver helper skipped it originally. Pinning it in the same `@<sha> # v2` format the rest of the file uses means Renovate's `github-actions` manager now tracks it — it will keep the digest refreshed and will still surface `v3` as a normal update PR. Renovate picks up where it left off; nothing about the config changes.

No change to the approval model: the AWS-dependent jobs stay gated on the `approval-required` environment, so maintainer approval remains required before any real-AWS acceptance run — pre-deploy gates still run automatically.

## 🔗 Related issues

<!-- none -->

## ✅ Checklist

- [ ] Tests added/updated <!-- n/a: CI workflow config only -->
- [x] CI passing <!-- validated locally: pre-commit (ruff/mypy/yaml) green; Semgrep confirmed via CI (registry blocked locally) -->
- [x] Docs updated (if needed) <!-- no doc surface affected -->
- [x] Ready for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eQ7AC4tg7H5YuD6HdZy3K

---
_Generated by [Claude Code](https://claude.ai/code/session_013eQ7AC4tg7H5YuD6HdZy3K)_