### PR TITLE
docs: complete README orientation (stack, deploy target, docs table)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 
 Manic tools for manipulating sets of tagged resources in AWS.
 
+**Stack:** Python ≥ 3.12 command-line library built on `boto3` (the only runtime dependency), packaged and locked with [`uv`](https://docs.astral.sh/uv/) and released by [Python Semantic Release](https://python-semantic-release.readthedocs.io/). CI runs on GitHub Actions; integration-test infrastructure is defined as an AWS SAM / CloudFormation template.
+
+**Deploy target:** Tagmania is a **library**, not a hosted service. It ships as the [`tagmania`](https://pypi.org/project/tagmania/) package on PyPI, and its API docs plus pipeline reports publish to [GitHub Pages](https://svange.github.io/tagmania/). The only cloud footprint is an *ephemeral* SAM/CloudFormation stack (`template.yaml`) that CI stands up to provide the `test1` integration-test cluster and tears down afterward — there is no production deployment.
+
 ---
 
 ## Pipeline Artifacts
@@ -22,6 +26,31 @@ Manic tools for manipulating sets of tagged resources in AWS.
 | PyPI | [pypi.org/project/tagmania](https://pypi.org/project/tagmania/) |
 
 Per-run downloadable artifacts (`bandit-report.json`, `pip-audit-report.json`, `coverage.xml`, `test-report.html`, `license-report.json`, built `dist/` on release) are available under the [Actions tab](https://github.com/svange/tagmania/actions) > select a run > scroll to "Artifacts".
+
+---
+
+## Documentation
+
+Start with the doc that matches what you're trying to do:
+
+| I want to… | Read |
+|------------|------|
+| Understand how the code fits together | [Architecture](#architecture) (in this README) |
+| Work in this repo as an AI agent | [`CLAUDE.md`](CLAUDE.md) — authoritative agent contract (commands, critical rules, CI/CD flow), mirrored for other assistants by [`AGENTS.md`](AGENTS.md) and [`.github/copilot-instructions.md`](.github/copilot-instructions.md) |
+| Follow real-world command recipes (runbook) | [`EXAMPLES.md`](EXAMPLES.md) — full-cluster backup/restore, targeted restore, cron snapshots, cross-region caveats |
+| Contribute code by hand | [`CONTRIBUTING.md`](CONTRIBUTING.md) |
+| Inspect the test-fixture infrastructure (IaC) | [`template.yaml`](template.yaml) — the AWS SAM stack CI uses for integration tests |
+| Report a security vulnerability | [`.github/SECURITY.md`](.github/SECURITY.md) |
+| Get help or ask a question | [`SUPPORT.md`](SUPPORT.md) |
+| Review the release history | [`CHANGELOG.md`](CHANGELOG.md) |
+
+---
+
+## Release & Branch Model
+
+Feature branches (`{type}/issue-N-description`) merge into **`main`**, which is both the default branch and the sole release source. Every push to `main` runs the [CI/CD pipeline](.github/workflows/publish.yaml): the required gates run, then [Python Semantic Release](https://python-semantic-release.readthedocs.io/) derives the next version from the Conventional Commit history, tags `v{version}`, publishes the wheel to [PyPI](https://pypi.org/project/tagmania/), and refreshes the [GitHub Pages](https://svange.github.io/tagmania/) reports.
+
+As a published library, Tagmania has no runtime environments (dev / staging / prod) to map branches onto — the PyPI release *is* the deploy. The only cloud infrastructure is the ephemeral SAM test stack CI creates and destroys on each run.
 
 ---
 


### PR DESCRIPTION
## 🚀 Summary

Brings the README up to the org **orientation-docs** pattern, closing the `docs.readme_orientation` compliance finding for this library repo. All changes are documentation-only (`README.md`); no code, workflows, or dependencies are touched.

What the finding flagged (verified against the checkout before editing):

- ✅ **Present, kept as-is:** first-paragraph purpose line, CI badge (Actions link), and the Pipeline Artifacts table with stable GitHub Pages URLs.
- ❌ **Purpose line lacked stack + deploy-target detail** → added two lines directly under the purpose statement:
  - **Stack:** Python ≥ 3.12 CLI library on `boto3`, packaged/locked with `uv`, released by Python Semantic Release; GitHub Actions CI; AWS SAM integration-test infra.
  - **Deploy target:** ships as the [`tagmania`](https://pypi.org/project/tagmania/) package on PyPI (it's a library, not a hosted service); docs/reports to GitHub Pages; only cloud footprint is the ephemeral SAM/CloudFormation test-fixture stack (`template.yaml`).
- ❌ **Documentation link table missing** → added a by-role table linking `CLAUDE.md` / `AGENTS.md` / `.github/copilot-instructions.md` (agent rules), the in-README Architecture section, `EXAMPLES.md` (runbook), `CONTRIBUTING.md`, `template.yaml` (IaC), `.github/SECURITY.md`, `SUPPORT.md`, and `CHANGELOG.md`.
- ⏭️ **Branch-to-environment mapping** was flagged N/A for a library repo. Rather than leave a gap, added a truthful **Release & Branch Model** section: `main` is the sole release source and PyPI is the deploy target; a library has no runtime environments to map branches onto.

Every link target was verified to exist, and the content is grounded in this repo's actual `pyproject.toml`, `.github/workflows/publish.yaml`, and `template.yaml` — no boilerplate.

## 🔗 Related issues

Part of the org compliance radiator "Orientation docs" remediation group. No operator-side steps (secrets, env vars, cloud actions) are required — this change is safe to merge as-is.

## ✅ Checklist

- [ ] Tests added/updated — n/a (docs-only)
- [x] CI passing — repo pre-commit hooks (`trailing-whitespace`, `end-of-file-fixer`, `gitleaks`) run locally against `README.md` and pass; latest `main` pipeline is green (no pre-existing red gate)
- [x] Docs updated (if needed)
- [x] Ready for review

## Automation note

Three open Renovate PRs (#48, #49, #50) exist but touch GitHub Actions/lockfile only — no overlap with this docs change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFxyNaGAgpRELxGvKENBai)_