### PR TITLE
ci: remove suppressed failures from pipeline post-gate jobs

### DIFF
--- a/.github/.ai-compliance.yaml
+++ b/.github/.ai-compliance.yaml
@@ -20,11 +20,10 @@ metadata:
   last_standardized: "2026-04-23"
   last_standardized_by: "7166607+svange@users.noreply.github.com"
 
-disabled_checks:
-  - id: workflow.no_cheating
-    reason: "Service pipeline uses continue-on-error/set+e in post-gate jobs (cleanup, release, docs) -- not
-  merge-decision gates"
-    created_at: 2026-04-23
-    approved_by: "samuelvange@gmail.com"
+# No opt-outs: the post-gate suppressions (cleanup/release/docs
+# continue-on-error, set +e, set +o pipefail, || true) that the former
+# workflow.no_cheating waiver covered have been removed from
+# .github/workflows/publish.yaml, so the pipeline now complies on its merits.
+disabled_checks: []
 
 overrides: {}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -378,10 +378,12 @@ jobs:
       group: testing-stack-${{ github.repository }}
       cancel-in-progress: false
     runs-on: ubuntu-latest
-    # Cleanup is best-effort: failures show red on this job but do not
-    # fail the workflow. Investigate red cleanup jobs -- usually a test
-    # template change or a terminal CloudFormation state.
-    continue-on-error: true
+    # Cleanup runs even when the acceptance tests fail (if: always() above)
+    # so the ephemeral test stack is always torn down. It is NOT a required
+    # status check, so a genuine teardown failure surfaces red on this job --
+    # investigate it (usually a test-template change or a terminal
+    # CloudFormation state) -- without blocking merges. A teardown failure is
+    # no longer silently swallowed.
     permissions:
       id-token: write
       contents: read
@@ -451,11 +453,11 @@ jobs:
 
       - name: Verify upstream has not changed
         run: |
-          set +o pipefail
-          UPSTREAM_BRANCH_NAME="$(git status -sb | head -n 1 | cut -d' ' -f2 | grep -E '\.{3}' | cut -d'.' -f4)"
-          set -o pipefail
-
-          if [ -z "$UPSTREAM_BRANCH_NAME" ]; then
+          # Read the tracking branch directly instead of parsing `git status`
+          # through a fragile head|grep pipeline that could abort on SIGPIPE
+          # or a non-matching grep. A missing upstream is handled explicitly
+          # below.
+          if ! UPSTREAM_BRANCH_NAME="$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null)"; then
               echo "::error::Unable to determine upstream branch name!"
               exit 1
           fi
@@ -481,19 +483,27 @@ jobs:
         run: |
           RELEASED="false"
 
-          set +e
-          uv run semantic-release --strict version
-          SEMANTIC_EXIT_CODE=$?
-          set -e
-
-          if [ $SEMANTIC_EXIT_CODE -eq 0 ]; then
+          # `semantic-release --strict version` exit codes:
+          #   0     -> a release was made
+          #   2     -> no release needed (nothing to release / already released)
+          #   other -> a genuine failure that must NOT be swallowed
+          # Running it as the `if` condition lets the shell tolerate the
+          # expected non-zero (exit 2) without aborting the step, while real
+          # errors (exit 1, etc.) still fail the step.
+          if uv run semantic-release --strict version; then
             echo "Semantic release succeeded"
             RELEASED="true"
           else
-            echo "No release needed"
+            SEMANTIC_EXIT_CODE=$?
+            if [ "$SEMANTIC_EXIT_CODE" -eq 2 ]; then
+              echo "No release needed"
+            else
+              echo "::error::semantic-release failed with exit code $SEMANTIC_EXIT_CODE"
+              exit "$SEMANTIC_EXIT_CODE"
+            fi
           fi
 
-          echo "released=$RELEASED" >> $GITHUB_OUTPUT
+          echo "released=$RELEASED" >> "$GITHUB_OUTPUT"
 
       - name: Upload distribution artifacts
         if: steps.release.outputs.released == 'true'
@@ -562,35 +572,37 @@ jobs:
       - name: Generate documentation
         run: |
           mkdir -p docs
-          uv run pdoc --output-dir docs src/tagmania || true
+          uv run pdoc --output-dir docs src/tagmania
 
+      # This job only runs after `release`, which needs the acceptance-tests,
+      # security, compliance and unit-tests jobs to succeed (implicit
+      # success() gate). Every report artifact below is therefore guaranteed
+      # to exist whenever this job runs, so the downloads are unguarded: a
+      # genuinely missing artifact is an anomaly that should fail loudly here
+      # rather than deploy an incomplete docs site.
       - name: Download coverage reports
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: coverage-reports
           path: docs/coverage
-        continue-on-error: true
 
       - name: Download security reports
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: security-reports
           path: docs/security
-        continue-on-error: true
 
       - name: Download compliance reports
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: compliance-reports
           path: docs/compliance
-        continue-on-error: true
 
       - name: Download unit test report
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: unit-test-reports
           path: docs/tests
-        continue-on-error: true
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0


### PR DESCRIPTION
## 🚀 Summary

Closes the org **`ci.no_suppressed_failures`** merge-gate finding [HIGH/L2] for this repo. The gate flagged **8 failure suppressions** in the CI/CD pipeline's *post-gate* jobs (`cleanup-test-infrastructure`, `release`, `docs`) — each masking a genuine failure behind `continue-on-error` / `set +e` / `set +o pipefail` / `|| true`. This PR removes all 8 while **preserving the capability each provided**. The required merge gates themselves (Code quality, Security, Compliance, Build validation, Unit tests, Acceptance tests) had no suppressions and are untouched.

Every finding was reproduced against the checkout before editing, and the riskiest logic changes were validated locally (exit-code branching under `set -eo pipefail`; `@{upstream}` resolves to `origin/main` from the same tracking config the old parse read).

**`.github/workflows/publish.yaml`**

| Job / step | Suppression removed | Capability preserved |
|---|---|---|
| `cleanup-test-infrastructure` | job-level `continue-on-error: true` | Still runs via `if: always()`, so the ephemeral test stack is always torn down. It is **not** a required check, so a genuine teardown failure now surfaces **red without blocking merges** instead of being silently swallowed. |
| `release` → *Verify upstream* | `set +o pipefail` around a `head\|grep` pipeline | Replaced with `git rev-parse --abbrev-ref --symbolic-full-name @{upstream}` — reads the identical `branch.<n>.remote/merge` tracking config, no pipefail dance, missing-upstream still handled explicitly. |
| `release` → *Run semantic release* | `set +e` capturing the exit code | Now distinguishes exit `2` (no release needed — the expected `--strict` signal, verified in `python-semantic-release` 10.6.1 source) from genuine errors (exit `1`, etc.), which **fail the step** instead of being reported as "no release needed". `released` output unchanged. |
| `docs` → *Generate documentation* | `\|\| true` on `pdoc` | A `pdoc` failure now fails the (non-required, push-only) docs job instead of deploying broken docs. |
| `docs` → 4× *Download …reports* | 4× `continue-on-error: true` | `docs` only runs after `release` succeeds, which needs the report-producing jobs (implicit `success()` gate), so every artifact is guaranteed present; a genuinely missing one now fails loudly. |

**`.github/.ai-compliance.yaml`**

- Removed the now-obsolete `workflow.no_cheating` opt-out. Its stated justification — "continue-on-error/set+e in post-gate jobs (cleanup, release, docs)" — describes exactly the suppressions deleted here, so the pipeline complies **on its merits** rather than via a waiver. `disabled_checks` is now empty.

## 🔗 Related issues

Part of the org compliance radiator **"Merge gates"** remediation group (the single failing standard in that group for this repo). 

**No operator-side steps are required** — no new required status checks, secrets, environment variables, or cloud actions; only steps *within existing jobs* changed, so no ruleset/branch-protection sync is needed and no operator-lane issues are filed.

**Heads-up (not a blocker):** the `cleanup` job's failure was previously masked. If teardown had been failing silently, the next `main`-push run will now show `cleanup-test-infrastructure` red — that's the intended visibility; investigate any orphaned `tagmania-testing` CloudFormation stack in AWS if so.

## Automation note

- No overlap with Renovate (open PRs #48/#49/#50 touch GitHub Actions pins / the lockfile only — not workflow logic).
- This repo has no `radar-remediation.yml` self-healing loop.
- A sibling compliance PR (#51, orientation-docs) is a different remediation group and touches only `README.md` — no conflict.

## ✅ Checklist

- [x] Tests added/updated — n/a (CI-config change only; the affected `release`/`docs` jobs run only on push to `main`, not on PRs)
- [x] CI passing — repo pre-commit hooks (check-yaml, gitleaks, EOF/whitespace, private-key/secret detection) run locally against both changed files and pass; `main` pipeline is green (no pre-existing red gate)
- [x] Docs updated (if needed) — n/a
- [x] Ready for review

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxEGNpTznzzqW7zhDooSqC)_